### PR TITLE
v0.2: チャットUIの刷新とFirestore連携（リアルタイム化）

### DIFF
--- a/src/app/entries/[date]/EntryClientPage.tsx
+++ b/src/app/entries/[date]/EntryClientPage.tsx
@@ -1,149 +1,99 @@
-'use client';
+'use client'
 
-import { useMemo, useState, useEffect, FormEvent } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
+import { ChevronLeft, Calendar } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { format, parseISO } from 'date-fns';
+import { ja } from 'date-fns/locale';
+import ChatInput from '@/components/ChatInput';
+import MessageBubble from '@/components/MessageBubble';
+import TabSwitcher from '@/components/TabSwitcher';
+import { cn } from '@/lib/utils';
 import { useAuth } from '@/context/AuthContext';
 import { useEntries } from '@/hooks/useEntries';
-import Header from '@/components/Header';
-import { parseISO, format } from 'date-fns';
-import { ja } from 'date-fns/locale';
-import { EntryType } from '@/lib/firebase';
+import { addDoc, collection, serverTimestamp, Timestamp } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
 
 type Props = {
   date: string;
   formattedDate: string;
 };
 
-export default function EntryClientPage({ date, formattedDate }: Props) {
-  const parsedDate = useMemo(() => parseISO(date), [date]);
-  const { user, loading: authLoading } = useAuth();
+function EntryClientPage({ date, formattedDate }: Props) {
   const router = useRouter();
+  const { user } = useAuth();
+  const [activeTab, setActiveTab] = useState<'plan' | 'record'>('plan');
+  const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  const [entryText, setEntryText] = useState('');
-  const [entryType, setEntryType] = useState<EntryType>('plan');
+  const parsedDate = useMemo(() => parseISO(date), [date]);
+  const { entries } = useEntries(user?.uid || '', parsedDate);
 
-  const { entries, loading: entriesLoading, addEntry } = useEntries(
-    user?.uid || null,
-    parsedDate
-  );
+  const addEntry = async (text: string, type: 'plan' | 'record') => {
+    if (!user) return;
 
-  useEffect(() => {
-    if (!authLoading && !user) {
-      router.push('/login');
-    }
-  }, [user, authLoading, router]);
-
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    if (!entryText.trim()) return;
-
-    await addEntry({
-      type: entryType,
-      text: entryText,
-      status: 'active',
+    await addDoc(collection(db, 'entries'), {
+      text,
+      targetDate: Timestamp.fromDate(parsedDate),
+      userId: user.uid,
+      type,
+      createdAt: serverTimestamp(),
     });
-
-    setEntryText('');
   };
 
-  if (authLoading || !user) {
-    return (
-      <div>
-        <Header />
-        <div className="flex justify-center items-center min-h-[80vh]">
-          <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
-        </div>
-      </div>
-    );
-  }
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [entries, activeTab]);
+
+  const goBack = () => router.push('/');
 
   return (
-    <div>
-      <Header />
-      <main className="container mx-auto p-4 max-w-3xl">
-        <div className="mb-6">
-          <button onClick={() => router.push('/')} className="text-blue-600 hover:underline flex items-center">
-            ← カレンダーに戻る
-          </button>
-          <h1 className="text-2xl font-bold mt-2">{formattedDate}の記録</h1>
+    <div className="flex flex-col h-screen bg-gray-50">
+      {/* ヘッダー */}
+      <header className="flex items-center p-4 border-b bg-white shadow-sm">
+        <Button variant="ghost" size="icon" onClick={goBack} className="mr-2">
+          <ChevronLeft className="h-5 w-5" />
+        </Button>
+        <div className="flex items-center">
+          <Calendar className="h-5 w-5 mr-2 text-gray-500" />
+          <h1 className="text-lg font-medium">{formattedDate}</h1>
         </div>
+      </header>
 
-        {/* 入力フォーム */}
-        <form onSubmit={handleSubmit} className="mb-8 bg-white p-4 rounded-lg shadow-md">
-          <div className="mb-4">
-            <div className="flex mb-2 space-x-4">
-              <label className="flex items-center">
-                <input
-                  type="radio"
-                  name="entryType"
-                  value="plan"
-                  checked={entryType === 'plan'}
-                  onChange={() => setEntryType('plan')}
-                  className="mr-2"
-                />
-                計画
-              </label>
-              <label className="flex items-center">
-                <input
-                  type="radio"
-                  name="entryType"
-                  value="record"
-                  checked={entryType === 'record'}
-                  onChange={() => setEntryType('record')}
-                  className="mr-2"
-                />
-                実績
-              </label>
-            </div>
-            <textarea
-              value={entryText}
-              onChange={(e) => setEntryText(e.target.value)}
-              className="w-full p-3 border rounded-lg focus:ring focus:ring-blue-300 focus:border-blue-500"
-              rows={4}
-              placeholder={entryType === 'plan' ? "今日の練習計画を入力..." : "実際の練習内容を記録..."}
-              required
-            />
-          </div>
-          <button
-            type="submit"
-            className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg"
-          >
-            投稿する
-          </button>
-        </form>
+      {/* タブ */}
+      <TabSwitcher activeTab={activeTab} onChange={setActiveTab} />
 
-        {/* 投稿表示 */}
-        <div className="space-y-4">
-          {entriesLoading ? (
-            <div className="flex justify-center items-center h-32">
-              <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-blue-500"></div>
-            </div>
-          ) : entries.length === 0 ? (
-            <div className="bg-gray-100 p-8 rounded-lg text-center text-gray-500">
-              この日の記録はまだありません。最初の記録を追加しましょう。
-            </div>
-          ) : (
-            entries.map((entry) => (
-              <div
-                key={entry.id}
-                className={`p-4 rounded-lg shadow-sm border-l-4 ${
-                  entry.type === 'plan' ? 'border-l-blue-500 bg-blue-50' : 'border-l-green-500 bg-green-50'
-                }`}
-              >
-                <div className="flex justify-between items-start mb-2">
-                  <span className="inline-block px-2 py-1 text-xs rounded text-white font-semibold bg-gray-700">
-                    {entry.type === 'plan' ? '計画' : '実績'}
-                  </span>
-                  <span className="text-xs text-gray-500">
-                    {entry.createdAt && format(entry.createdAt.toDate(), 'HH:mm')}
-                  </span>
-                </div>
-                <p className="whitespace-pre-wrap">{entry.text}</p>
+      {/* スレッド表示 */}
+      <div
+        className={cn(
+          'flex-1 overflow-y-auto p-4 space-y-4',
+          activeTab === 'plan' ? 'bg-blue-50' : 'bg-green-50'
+        )}
+      >
+        {entries
+          .filter((entry) => entry.type === activeTab)
+          .sort((a, b) => {
+            const aTime = a.createdAt?.toMillis?.() ?? 0;
+            const bTime = b.createdAt?.toMillis?.() ?? 0;
+            return aTime - bTime;
+          })
+          .map((entry) => (
+            <div key={entry.id} className="flex flex-col space-y-1">
+              <div className="text-xs text-gray-500 ml-2">
+                {entry.createdAt?.toDate ? format(entry.createdAt.toDate(), 'HH:mm') : ''}
               </div>
-            ))
-          )}
-        </div>
-      </main>
+              <MessageBubble entry={entry} />
+            </div>
+          ))}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* 入力欄 */}
+      <div className="border-t bg-white p-2">
+        <ChatInput activeTab={activeTab} onSend={(text) => addEntry(text, activeTab)} />
+      </div>
     </div>
   );
 }
+
+export default EntryClientPage;

--- a/src/app/entries/[date]/page.tsx
+++ b/src/app/entries/[date]/page.tsx
@@ -1,13 +1,16 @@
-// src/app/entries/[date]/page.tsx
+// app/entries/[date]/page.tsx
 
 import { parseISO, format } from 'date-fns';
 import { ja } from 'date-fns/locale';
 import EntryClientPage from './EntryClientPage';
 
-export default async function EntriesPage({ params }: any) {
-  const { date } = params;
+type Params = {
+  date: string;
+};
+
+export default async function Page({ params }: { params: Promise<Params> }) {
+  const { date } = await params;
   const parsedDate = parseISO(date);
   const formattedDate = format(parsedDate, 'yyyy年M月d日 (EEEE)', { locale: ja });
-
   return <EntryClientPage date={date} formattedDate={formattedDate} />;
 }

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { useState, type FormEvent } from "react"
+import { Send } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+interface ChatInputProps {
+  activeTab: "plan" | "record"
+  onSend: (text: string) => void
+}
+
+export default function ChatInput({ activeTab, onSend }: ChatInputProps) {
+  const [text, setText] = useState("")
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    if (text.trim()) {
+      onSend(text)
+      setText("")
+    }
+  }
+
+  const placeholderText = activeTab === "plan" ? "今日の計画を入力..." : "今日の実績を入力..."
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={cn("flex items-center gap-2 p-3", activeTab === "plan" ? "bg-blue-50" : "bg-green-50")}
+    >
+      <div className="relative flex-1">
+        <input
+          type="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder={placeholderText}
+          className={cn(
+            "w-full p-3 pr-10 rounded-full border bg-white focus:outline-none focus:ring-2",
+            activeTab === "plan" ? "focus:ring-blue-300 border-blue-200" : "focus:ring-green-300 border-green-200",
+          )}
+        />
+      </div>
+      <Button
+        type="submit"
+        size="icon"
+        className={cn(
+          "rounded-full h-12 w-12 flex items-center justify-center",
+          activeTab === "plan" ? "bg-blue-500 hover:bg-blue-600" : "bg-green-500 hover:bg-green-600",
+        )}
+        disabled={!text.trim()}
+      >
+        <Send className="h-5 w-5" />
+      </Button>
+    </form>
+  )
+}
+

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@/lib/utils"
+
+type Entry = {
+  id: string
+  text: string
+  createdAt: Date
+  userId: string
+  type: "plan" | "record"
+}
+
+interface MessageBubbleProps {
+  entry: Entry
+}
+
+export default function MessageBubble({ entry }: MessageBubbleProps) {
+  return (
+    <div className="flex flex-col">
+      <div className={cn("p-4 rounded-2xl max-w-[85%] break-words bg-white shadow-sm", "border border-gray-100")}>
+        <div className="flex items-center gap-2 mb-1.5">
+          <div
+            className={cn(
+              "text-xs font-medium px-2 py-0.5 rounded-full",
+              entry.type === "plan" ? "bg-blue-100 text-blue-700" : "bg-green-100 text-green-700",
+            )}
+          >
+            {entry.type === "plan" ? "計画" : "実績"}
+          </div>
+        </div>
+        <p className="whitespace-pre-wrap text-gray-800">{entry.text}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/TabSwitcher.tsx
+++ b/src/components/TabSwitcher.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+interface TabSwitcherProps {
+  activeTab: "plan" | "record"
+  onChange: (tab: "plan" | "record") => void
+}
+
+export default function TabSwitcher({ activeTab, onChange }: TabSwitcherProps) {
+  return (
+    <div className="flex border-b bg-white shadow-sm">
+      <button
+        className={cn(
+          "flex-1 py-3.5 text-center font-medium transition-colors",
+          activeTab === "plan"
+            ? "text-blue-600 border-b-2 border-blue-500 bg-blue-50"
+            : "text-gray-500 hover:text-gray-700 hover:bg-gray-50",
+        )}
+        onClick={() => onChange("plan")}
+      >
+        計画 (Plan)
+      </button>
+      <button
+        className={cn(
+          "flex-1 py-3.5 text-center font-medium transition-colors",
+          activeTab === "record"
+            ? "text-green-600 border-b-2 border-green-500 bg-green-50"
+            : "text-gray-500 hover:text-gray-700 hover:bg-gray-50",
+        )}
+        onClick={() => onChange("record")}
+      >
+        実績 (Record)
+      </button>
+    </div>
+  )
+}

--- a/src/components/ThreadView.tsx
+++ b/src/components/ThreadView.tsx
@@ -1,0 +1,24 @@
+// src/components/ThreadView.tsx
+'use client';
+
+import { Entry } from '@/types/entry';
+import { format } from 'date-fns';
+
+type Props = {
+  entries: Entry[];
+};
+
+export default function ThreadView({ entries }: Props) {
+  return (
+    <div className="flex flex-col space-y-4 pb-32 px-4">
+      {entries.map((entry) => (
+        <div key={entry.id} className="flex flex-col">
+          <span className="text-xs text-gray-500">{format(entry.createdAt.toDate(), 'yyyy/MM/dd HH:mm')}</span>
+          <div className="bg-gray-100 rounded-xl px-4 py-2 max-w-xs">
+            <p className="text-sm whitespace-pre-wrap">{entry.text}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,16 @@
+// src/components/ui/button.tsx
+'use client';
+
+import { ButtonHTMLAttributes } from 'react';
+
+export function Button({
+  className,
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement> & { className?: string }) {
+  return (
+    <button
+      className={`bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 ${className || ''}`}
+      {...props}
+    />
+  );
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,5 @@
+// src/lib/utils.ts
+export function cn(...classes: (string | false | null | undefined)[]) {
+    return classes.filter(Boolean).join(" ");
+  }
+  

--- a/src/types/entry.ts
+++ b/src/types/entry.ts
@@ -1,0 +1,9 @@
+// src/types/entry.ts
+export type Entry = {
+    id: string;
+    text: string;
+    createdAt: any;
+    userId: string;
+    type: 'plan' | 'record';
+  };
+  


### PR DESCRIPTION
## 概要
- v0.2リリースに向けたスレッドUIの整理とFirestoreとのリアルタイム連携対応

## 主な変更内容
- EntryClientPage.tsx の再設計
- ChatInput, TabSwitcher, MessageBubbleの導入
- FirestoreのonSnapshot対応により即時反映
- 投稿種別(plan/record)の切り替えUI追加
- カレンダービューとの連携維持

## 今後予定
- v0.3: STRAVAデータのスレッド上部表示
- v0.4: カレンダーUIの強化
- v0.5: GPTによる投稿補助・要約
